### PR TITLE
Added the ability to handle parsing of multiline string values.

### DIFF
--- a/include/rapidjson/error/error.h
+++ b/include/rapidjson/error/error.h
@@ -86,7 +86,9 @@ enum ParseErrorCode {
     kParseErrorNumberMissExponent,              //!< Miss exponent in number.
 
     kParseErrorTermination,                     //!< Parsing was terminated.
-    kParseErrorUnspecificSyntaxError            //!< Unspecific syntax error.
+    kParseErrorUnspecificSyntaxError,            //!< Unspecific syntax error.
+
+    kParseErrorInvalidFlagCombination           //!< Invalid combination of ParseFlags.
 };
 
 //! Result of parsing (wraps ParseErrorCode)

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1046,18 +1046,15 @@ private:
 					RAPIDJSON_PARSE_ERROR(kParseErrorStringMissQuotationMark, is.Tell());
 				else if (!isKey && c == '\n' && (parseFlags & kParseMultiLineStringValueFlag)) {
 					is.Take();
-					os.Put('\\');
-					os.Put('n');
+					os.Put('\n');
 				}
 				else if (!isKey && c == '\t' && (parseFlags & kParseMultiLineStringValueFlag)) {
 					is.Take();
-					os.Put('\\');
-					os.Put('t');
+					os.Put('\t');
 				}
 				else if (!isKey && c == '\r' && (parseFlags & kParseMultiLineStringValueFlag)) {
 					is.Take();
-					os.Put('\\');
-					os.Put('r');
+					os.Put('\r');
 				}
                 else
                     RAPIDJSON_PARSE_ERROR(kParseErrorStringInvalidEncoding, is.Tell());

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -955,9 +955,9 @@ private:
 
     // Parse string and generate String event. Different code paths for kParseInsituFlag.
     template<unsigned parseFlags, typename InputStream, typename Handler>
-	void ParseString(InputStream& is, Handler& handler, bool isKey = false) {
-		if ((parseFlags & kParseInsituFlag) && (parseFlags & kParseMultiLineStringValueFlag))
-			RAPIDJSON_PARSE_ERROR(kParseErrorInvalidFlagCombination, is.Tell());
+    void ParseString(InputStream& is, Handler& handler, bool isKey = false) {
+        if ((parseFlags & kParseInsituFlag) && (parseFlags & kParseMultiLineStringValueFlag))
+            RAPIDJSON_PARSE_ERROR(kParseErrorInvalidFlagCombination, is.Tell());
 
         internal::StreamLocalCopy<InputStream> copy(is);
         InputStream& s(copy.s);
@@ -1043,7 +1043,7 @@ private:
             }
             else if (RAPIDJSON_UNLIKELY(static_cast<unsigned>(c) < 0x20)) { // RFC 4627: unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
                 if (c == '\0')
-					RAPIDJSON_PARSE_ERROR(kParseErrorStringMissQuotationMark, is.Tell());
+                    RAPIDJSON_PARSE_ERROR(kParseErrorStringMissQuotationMark, is.Tell());
                 else if (!isKey && c == '\n' && (parseFlags & kParseMultiLineStringValueFlag)) {
                     is.Take();
                     os.Put('\n');

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1044,17 +1044,9 @@ private:
             else if (RAPIDJSON_UNLIKELY(static_cast<unsigned>(c) < 0x20)) { // RFC 4627: unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
                 if (c == '\0')
                     RAPIDJSON_PARSE_ERROR(kParseErrorStringMissQuotationMark, is.Tell());
-                else if (!isKey && c == '\n' && (parseFlags & kParseMultiLineStringValueFlag)) {
+                else if (!isKey && (parseFlags & kParseMultiLineStringValueFlag) && (c == '\n' || c == '\r' || c == '\t')) {
                     is.Take();
-                    os.Put('\n');
-                }
-                else if (!isKey && c == '\t' && (parseFlags & kParseMultiLineStringValueFlag)) {
-                    is.Take();
-                    os.Put('\t');
-                }
-                else if (!isKey && c == '\r' && (parseFlags & kParseMultiLineStringValueFlag)) {
-                    is.Take();
-                    os.Put('\r');
+                    os.Put(c);
                 }
                 else
                     RAPIDJSON_PARSE_ERROR(kParseErrorStringInvalidEncoding, is.Tell());

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -152,8 +152,8 @@ enum ParseFlag {
     kParseCommentsFlag = 32,        //!< Allow one-line (//) and multi-line (/**/) comments.
     kParseNumbersAsStringsFlag = 64,    //!< Parse all numbers (ints/doubles) as strings.
     kParseTrailingCommasFlag = 128, //!< Allow trailing commas at the end of objects and arrays.
-	kParseNanAndInfFlag = 256,      //!< Allow parsing NaN, Inf, Infinity, -Inf and -Infinity as doubles.
-	kParseMultiLineStringValueFlag = 512, //!< Allow parsing multi-line string values.
+    kParseNanAndInfFlag = 256,      //!< Allow parsing NaN, Inf, Infinity, -Inf and -Infinity as doubles.
+    kParseMultiLineStringValueFlag = 512, //!< Allow parsing multi-line string values.
     kParseDefaultFlags = RAPIDJSON_PARSE_DEFAULT_FLAGS  //!< Default parse flags. Can be customized by defining RAPIDJSON_PARSE_DEFAULT_FLAGS
 };
 
@@ -1044,18 +1044,18 @@ private:
             else if (RAPIDJSON_UNLIKELY(static_cast<unsigned>(c) < 0x20)) { // RFC 4627: unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
                 if (c == '\0')
 					RAPIDJSON_PARSE_ERROR(kParseErrorStringMissQuotationMark, is.Tell());
-				else if (!isKey && c == '\n' && (parseFlags & kParseMultiLineStringValueFlag)) {
-					is.Take();
-					os.Put('\n');
-				}
-				else if (!isKey && c == '\t' && (parseFlags & kParseMultiLineStringValueFlag)) {
-					is.Take();
-					os.Put('\t');
-				}
-				else if (!isKey && c == '\r' && (parseFlags & kParseMultiLineStringValueFlag)) {
-					is.Take();
-					os.Put('\r');
-				}
+                else if (!isKey && c == '\n' && (parseFlags & kParseMultiLineStringValueFlag)) {
+                    is.Take();
+                    os.Put('\n');
+                }
+                else if (!isKey && c == '\t' && (parseFlags & kParseMultiLineStringValueFlag)) {
+                    is.Take();
+                    os.Put('\t');
+                }
+                else if (!isKey && c == '\r' && (parseFlags & kParseMultiLineStringValueFlag)) {
+                    is.Take();
+                    os.Put('\r');
+                }
                 else
                     RAPIDJSON_PARSE_ERROR(kParseErrorStringInvalidEncoding, is.Tell());
             }


### PR DESCRIPTION
Rapidjson does not support multiline string values. This poses an issue for upgrade paths, where past Marketplace Content has such multiline strings AND where we switch loading code over to use rapidjson (e.g. switch from JsonSchema to Cereal does that switch to rapidjson). This PR adds support for parsing multiline string values.