### PR TITLE
User Story 616480:Enable PREFast warnings as errors. [Error Type: C26495: Uninitialized member variable] - Submodule rapidjson 

### DIFF
--- a/include/rapidjson/internal/ieee754.h
+++ b/include/rapidjson/internal/ieee754.h
@@ -22,7 +22,7 @@ namespace internal {
 
 class Double {
 public:
-    Double() : u_(0) {}
+    Double() : d_(0.0) {}
     Double(double d) : d_(d) {}
     Double(uint64_t u) : u_(u) {}
 


### PR DESCRIPTION
### [ADO](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**ado**)
- https://dev-mc.visualstudio.com/Minecraft/_workitems/edit/616480

<!-- *** EDIT_NUMBER_INTO_LINK_ABOVE_REPLACING_### ***
    - Include a link to each work item on ADO for the user story, bugfix, etc.
    - If there is not an ADO work item for the PR, then consider making one.
-->



### [Description / PR Commit Message](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**description-%2F-pr-commit-message**)

<!-- *** COMMENT_DESCRIPTION_PR_COMMIT_MESSAGE ***
    - Add a description of the PR and why it is being made.
    - May contain root cause, perf impact, background info, system design, changes made, creator impact, etc.
    - Upon merging, copy the text you typed below here and use that as the PR Commit Message.
-->
Check with PREFast, found 2 errors:
```
1. C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\ieee754.h(25): Error C26495: Variable 'rapidjson::internal::Double::<unnamed-tag>::u_' is uninitialized. Always initialize a member variable (type.6).
2. C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\ieee754.h(25): Error C26495: Variable 'rapidjson::internal::Double::<unnamed-tag>::d_' is uninitialized. Always initialize a member variable (type.6).
```
The modifications are as following:
According to modification suggestions, so initialize a member variable.


### [Guidance for Review](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**guidance-for-review**)

<!-- *** COMMENT__GUIDANCE_FOR_REVIEW ***
    - Provide additional information to ease review of this PR; this section does not survive into git history.
    - May contain: what you dev tested, perf captures, screenshots, requested feedback, recommended order to review files in, auto test reliability results, changelog exemption reason, test review exemption reason, etc.
-->
Synchronize with mojang_main on 2021-10-08.


### [Author's Checklist](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**author%27s-checklist**)
- [x] Completed Automated Test Review or have Exemption ([automated test policy](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/4447)).
- [x] Have Changelogs for Public Changes or have Exemption ([changelogs policy](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/3921/Pull-Request-Changelogs)).
- [x] Set the Manual Quality Validation Required field and applicable Validation Notes in ADO item(s).
- [x] Builds and Test Runs passed.
- [x] Reliability runs of affected tests passed (Unit 1 time, Server 10 time, Functional 50 times).



### [Reviewers' Checklist](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**reviewers%27-checklist**)
- [x] Correct target branch.
- [x] Reason/root cause understood; documented in Description / PR Commit message.
- [x] Architecturally fits accepted patterns.
- [x] Introduced no known bugs and is secure.
- [x] No hard-coded "secrets".
- [x] Follows Coding Standards ([contributing.md](https://github.com/Mojang/Minecraftpe/blob/main/CONTRIBUTING.md)).
- [x] Content creator impact is understood and acceptable.
