### PR TITLE
User Story 618718: Enable PREFast warnings as errors. [Error Type: C26494: Uninitialized variable] - Submodule rapidjson

### DIFF
--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -186,8 +186,9 @@ public:
     bool Difference(const BigInteger& rhs, BigInteger* out) const {
         int cmp = Compare(rhs);
         RAPIDJSON_ASSERT(cmp != 0);
-        const BigInteger *a, *b;  // Makes a > b
-        bool ret;
+        const BigInteger* a = nullptr;  // Makes a > b
+        const BigInteger* b = nullptr;
+        bool ret = false;
         if (cmp < 0) { a = &rhs; b = this; ret = true; }
         else         { a = this; b = &rhs; ret = false; }
 

--- a/include/rapidjson/internal/diyfp.h
+++ b/include/rapidjson/internal/diyfp.h
@@ -142,7 +142,7 @@ struct DiyFp {
         union {
             double d;
             uint64_t u64;
-        }u;
+        }u = {};
         RAPIDJSON_ASSERT(f <= kDpHiddenBit + kDpSignificandMask);
         if (e < kDpDenormalExponent) {
             // Underflow.

--- a/include/rapidjson/internal/stack.h
+++ b/include/rapidjson/internal/stack.h
@@ -182,7 +182,7 @@ private:
     template<typename T>
     void Expand(size_t count) {
         // Only expand the capacity if the current stack exists. Otherwise just create a stack with initial capacity.
-        size_t newCapacity;
+        size_t newCapacity = 0;
         if (stack_ == 0) {
             if (!allocator_)
                 ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator)();

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1575,7 +1575,7 @@ private:
 
         // Parse frac = decimal-point 1*DIGIT
         int expFrac = 0;
-        size_t decimalPosition;
+        size_t decimalPosition = 0;
         if (Consume(s, '.')) {
             decimalPosition = s.Length();
 


### PR DESCRIPTION
### [ADO](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**ado**)
- https://dev-mc.visualstudio.com/Minecraft/_workitems/edit/616487

<!-- *** EDIT_NUMBER_INTO_LINK_ABOVE_REPLACING_### ***
    - Include a link to each work item on ADO for the user story, bugfix, etc.
    - If there is not an ADO work item for the PR, then consider making one.
-->

### [Description / PR Commit Message](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**description-%2F-pr-commit-message**)

<!-- *** COMMENT_DESCRIPTION_PR_COMMIT_MESSAGE ***
    - Add a description of the PR and why it is being made.
    - May contain root cause, perf impact, background info, system design, changes made, creator impact, etc.
    - Upon merging, copy the text you typed below here and use that as the PR Commit Message.
-->
Check with PREFast, found 1 error:

 ` C:\Minecraftpe\handheld\src-deps\leveldb_\leveldb\include\leveldb\cache.h(34): Error C26495: Variable 'leveldb::Cache::rep_' is uninitialized. Always initialize a member variable (type.6).`


The modifications are as following:

Initializes a member variable that is not initialized in the constructor.

### [Guidance for Review](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**guidance-for-review**)

<!-- *** COMMENT__GUIDANCE_FOR_REVIEW ***
    - Provide additional information to ease review of this PR; this section does not survive into git history.
    - May contain: what you dev tested, perf captures, screenshots, requested feedback, recommended order to review files in, auto test reliability results, changelog exemption reason, test review exemption reason, etc.
-->
Synchronize with main on 2021-09-28.


### [Author's Checklist](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**author%27s-checklist**)
- [ ] Completed Automated Test Review or have Exemption ([automated test policy](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/4447)).
- [ ] Have Changelogs for Public Changes or have Exemption ([changelogs policy](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/3921/Pull-Request-Changelogs)).
- [x] Set the Manual Quality Validation Required field and applicable Validation Notes in ADO item(s).
- [x] Builds and Test Runs passed.
- [x] Reliability runs of affected tests passed (Unit 1 time, Server 10 time, Functional 50 times).



### [Reviewers' Checklist](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**reviewers%27-checklist**)
- [ ] Correct target branch.
- [ ] Reason/root cause understood; documented in Description / PR Commit message.
- [ ] Architecturally fits accepted patterns.
- [ ] Introduced no known bugs and is secure.
- [ ] No hard-coded "secrets".
- [ ] Follows Coding Standards ([contributing.md](https://github.com/Mojang/Minecraftpe/blob/main/CONTRIBUTING.md)).
- [ ] Content creator impact is understood and acceptable.

