### PR TITLE
User Story 647089: Enable PREFast warnings as errors.  [Error Type: C26429: Use not null] -Minecraft.Shared.Splits-Submodule  rapidjson

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -807,10 +807,7 @@ public:
                     for (GenericValue* v = e; v != e + data_.a.size; ++v) {
                         RAPIDJSON_ASSERT(v != nullptr);
                         v->~GenericValue();
-<<<<<<< Updated upstream
-=======
                     }
->>>>>>> Stashed changes
                     Allocator::Free(e);
                 }
                 break;

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -803,8 +803,14 @@ public:
             case kArrayFlag:
                 {
                     GenericValue* e = GetElementsPointer();
-                    for (GenericValue* v = e; v != e + data_.a.size; ++v)
+                    RAPIDJSON_ASSERT(e != nullptr);
+                    for (GenericValue* v = e; v != e + data_.a.size; ++v) {
+                        RAPIDJSON_ASSERT(v != nullptr);
                         v->~GenericValue();
+<<<<<<< Updated upstream
+=======
+                    }
+>>>>>>> Stashed changes
                     Allocator::Free(e);
                 }
                 break;
@@ -2066,6 +2072,7 @@ private:
     //! Initialize this value as copy string with initial data, without calling destructor.
     void SetStringRaw(StringRefType s, Allocator& allocator) {
         Ch* str = 0;
+        RAPIDJSON_ASSERT(str != nullptr);
         if (ShortString::Usable(s.length)) {
             data_.f.flags = kShortStringFlag;
             data_.ss.SetLength(s.length);

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -2069,7 +2069,6 @@ private:
     //! Initialize this value as copy string with initial data, without calling destructor.
     void SetStringRaw(StringRefType s, Allocator& allocator) {
         Ch* str = 0;
-        RAPIDJSON_ASSERT(str != nullptr);
         if (ShortString::Usable(s.length)) {
             data_.f.flags = kShortStringFlag;
             data_.ss.SetLength(s.length);
@@ -2080,6 +2079,7 @@ private:
             str = static_cast<Ch *>(allocator.Malloc((s.length + 1) * sizeof(Ch)));
             SetStringPointer(str);
         }
+        RAPIDJSON_ASSERT(str != nullptr);
         std::memcpy(str, s, s.length * sizeof(Ch));
         str[s.length] = '\0';
     }

--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -186,8 +186,9 @@ public:
     bool Difference(const BigInteger& rhs, BigInteger* out) const {
         int cmp = Compare(rhs);
         RAPIDJSON_ASSERT(cmp != 0);
-        const BigInteger *a, *b;  // Makes a > b
-        bool ret;
+        const BigInteger* a = nullptr;  // Makes a > b
+        const BigInteger* b = nullptr;
+        bool ret = false;
         if (cmp < 0) { a = &rhs; b = this; ret = true; }
         else         { a = this; b = &rhs; ret = false; }
 

--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -240,6 +240,10 @@ private:
     static uint64_t ParseUint64(const char* begin, const char* end) {
         uint64_t r = 0;
         for (const char* p = begin; p != end; ++p) {
+<<<<<<< Updated upstream
+=======
+            RAPIDJSON_ASSERT(p != nullptr);
+>>>>>>> Stashed changes
             RAPIDJSON_ASSERT(*p >= '0' && *p <= '9');
             r = r * 10u + static_cast<unsigned>(*p - '0');
         }
@@ -248,6 +252,7 @@ private:
 
     // Assume a * b + k < 2^128
     static uint64_t MulAdd64(uint64_t a, uint64_t b, uint64_t k, uint64_t* outHigh) {
+        RAPIDJSON_ASSERT(outHigh != nullptr);
 #if defined(_MSC_VER) && defined(_M_AMD64)
         uint64_t low = _umul128(a, b, outHigh) + k;
         if (low < k)

--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -186,9 +186,8 @@ public:
     bool Difference(const BigInteger& rhs, BigInteger* out) const {
         int cmp = Compare(rhs);
         RAPIDJSON_ASSERT(cmp != 0);
-        const BigInteger* a = nullptr;  // Makes a > b
-        const BigInteger* b = nullptr;
-        bool ret = false;
+        const BigInteger *a, *b;  // Makes a > b
+        bool ret;
         if (cmp < 0) { a = &rhs; b = this; ret = true; }
         else         { a = this; b = &rhs; ret = false; }
 
@@ -240,10 +239,7 @@ private:
     static uint64_t ParseUint64(const char* begin, const char* end) {
         uint64_t r = 0;
         for (const char* p = begin; p != end; ++p) {
-<<<<<<< Updated upstream
-=======
             RAPIDJSON_ASSERT(p != nullptr);
->>>>>>> Stashed changes
             RAPIDJSON_ASSERT(*p >= '0' && *p <= '9');
             r = r * 10u + static_cast<unsigned>(*p - '0');
         }

--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -240,8 +240,7 @@ private:
     static uint64_t ParseUint64(const char* begin, const char* end) {
         uint64_t r = 0;
         for (const char* p = begin; p != end; ++p) {
-            RAPIDJSON_ASSERT(p != nullptr);
-            RAPIDJSON_ASSERT(*p >= '0' && *p <= '9');
+            RAPIDJSON_ASSERT(p != nullptr && *p >= '0' && *p <= '9');
             r = r * 10u + static_cast<unsigned>(*p - '0');
         }
         return r;

--- a/include/rapidjson/internal/diyfp.h
+++ b/include/rapidjson/internal/diyfp.h
@@ -142,7 +142,7 @@ struct DiyFp {
         union {
             double d;
             uint64_t u64;
-        }u;
+        }u = {};
         RAPIDJSON_ASSERT(f <= kDpHiddenBit + kDpSignificandMask);
         if (e < kDpDenormalExponent) {
             // Underflow.

--- a/include/rapidjson/internal/diyfp.h
+++ b/include/rapidjson/internal/diyfp.h
@@ -236,7 +236,7 @@ inline DiyFp GetCachedPowerByIndex(size_t index) {
 }
 
 inline DiyFp GetCachedPower(int e, int* K) {
-
+    RAPIDJSON_ASSERT(K != nullptr);
     //int k = static_cast<int>(ceil((-61 - e) * 0.30102999566398114)) + 374;
     double dk = (-61 - e) * 0.30102999566398114 + 347;  // dk must be positive, so can do ceiling in positive
     int k = static_cast<int>(dk);
@@ -250,6 +250,7 @@ inline DiyFp GetCachedPower(int e, int* K) {
 }
 
 inline DiyFp GetCachedPower10(int exp, int *outExp) {
+    RAPIDJSON_ASSERT(outExp != nullptr);
     RAPIDJSON_ASSERT(exp >= -348);
     unsigned index = static_cast<unsigned>(exp + 348) / 8u;
     *outExp = -348 + static_cast<int>(index) * 8;

--- a/include/rapidjson/internal/diyfp.h
+++ b/include/rapidjson/internal/diyfp.h
@@ -142,7 +142,7 @@ struct DiyFp {
         union {
             double d;
             uint64_t u64;
-        }u = {};
+        }u;
         RAPIDJSON_ASSERT(f <= kDpHiddenBit + kDpSignificandMask);
         if (e < kDpDenormalExponent) {
             // Underflow.

--- a/include/rapidjson/internal/diyfp.h
+++ b/include/rapidjson/internal/diyfp.h
@@ -235,8 +235,7 @@ inline DiyFp GetCachedPowerByIndex(size_t index) {
     return DiyFp(kCachedPowers_F[index], kCachedPowers_E[index]);
 }
 
-inline DiyFp GetCachedPower(int e, int* K) {
-    RAPIDJSON_ASSERT(K != nullptr);
+inline DiyFp GetCachedPower(int e, int& K) {
     //int k = static_cast<int>(ceil((-61 - e) * 0.30102999566398114)) + 374;
     double dk = (-61 - e) * 0.30102999566398114 + 347;  // dk must be positive, so can do ceiling in positive
     int k = static_cast<int>(dk);
@@ -244,16 +243,15 @@ inline DiyFp GetCachedPower(int e, int* K) {
         k++;
 
     unsigned index = static_cast<unsigned>((k >> 3) + 1);
-    *K = -(-348 + static_cast<int>(index << 3));    // decimal exponent no need lookup table
+    K = -(-348 + static_cast<int>(index << 3));    // decimal exponent no need lookup table
 
     return GetCachedPowerByIndex(index);
 }
 
-inline DiyFp GetCachedPower10(int exp, int *outExp) {
-    RAPIDJSON_ASSERT(outExp != nullptr);
+inline DiyFp GetCachedPower10(int exp, int& outExp) {
     RAPIDJSON_ASSERT(exp >= -348);
     unsigned index = static_cast<unsigned>(exp + 348) / 8u;
-    *outExp = -348 + static_cast<int>(index) * 8;
+    outExp = -348 + static_cast<int>(index) * 8;
     return GetCachedPowerByIndex(index);
 }
 

--- a/include/rapidjson/internal/diyfp.h
+++ b/include/rapidjson/internal/diyfp.h
@@ -236,6 +236,7 @@ inline DiyFp GetCachedPowerByIndex(size_t index) {
 }
 
 inline DiyFp GetCachedPower(int e, int& K) {
+
     //int k = static_cast<int>(ceil((-61 - e) * 0.30102999566398114)) + 374;
     double dk = (-61 - e) * 0.30102999566398114 + 347;  // dk must be positive, so can do ceiling in positive
     int k = static_cast<int>(dk);

--- a/include/rapidjson/internal/dtoa.h
+++ b/include/rapidjson/internal/dtoa.h
@@ -59,12 +59,9 @@ inline int CountDecimalDigit32(uint32_t n) {
 }
 
 inline void DigitGen(const DiyFp& W, const DiyFp& Mp, uint64_t delta, char* buffer, int* len, int* K) {
-<<<<<<< Updated upstream
-=======
     RAPIDJSON_ASSERT(buffer != 0);
     RAPIDJSON_ASSERT(len != 0);
     RAPIDJSON_ASSERT(K != 0);
->>>>>>> Stashed changes
     static const uint32_t kPow10[] = { 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000 };
     const DiyFp one(uint64_t(1) << -Mp.e, Mp.e);
     const DiyFp wp_w = Mp - W;

--- a/include/rapidjson/internal/dtoa.h
+++ b/include/rapidjson/internal/dtoa.h
@@ -59,9 +59,9 @@ inline int CountDecimalDigit32(uint32_t n) {
 }
 
 inline void DigitGen(const DiyFp& W, const DiyFp& Mp, uint64_t delta, char* buffer, int* len, int* K) {
-    RAPIDJSON_ASSERT(buffer != 0);
-    RAPIDJSON_ASSERT(len != 0);
-    RAPIDJSON_ASSERT(K != 0);
+    RAPIDJSON_ASSERT(buffer != nullptr);
+    RAPIDJSON_ASSERT(len != nullptr);
+    RAPIDJSON_ASSERT(K != nullptr);
     static const uint32_t kPow10[] = { 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000 };
     const DiyFp one(uint64_t(1) << -Mp.e, Mp.e);
     const DiyFp wp_w = Mp - W;

--- a/include/rapidjson/internal/dtoa.h
+++ b/include/rapidjson/internal/dtoa.h
@@ -33,6 +33,7 @@ RAPIDJSON_DIAG_OFF(array-bounds) // some gcc versions generate wrong warnings ht
 #endif
 
 inline void GrisuRound(char* buffer, int len, uint64_t delta, uint64_t rest, uint64_t ten_kappa, uint64_t wp_w) {
+    RAPIDJSON_ASSERT(buffer != nullptr);
     while (rest < wp_w && delta - rest >= ten_kappa &&
            (rest + ten_kappa < wp_w ||  /// closer
             wp_w - rest > rest + ten_kappa - wp_w)) {
@@ -58,6 +59,12 @@ inline int CountDecimalDigit32(uint32_t n) {
 }
 
 inline void DigitGen(const DiyFp& W, const DiyFp& Mp, uint64_t delta, char* buffer, int* len, int* K) {
+<<<<<<< Updated upstream
+=======
+    RAPIDJSON_ASSERT(buffer != 0);
+    RAPIDJSON_ASSERT(len != 0);
+    RAPIDJSON_ASSERT(K != 0);
+>>>>>>> Stashed changes
     static const uint32_t kPow10[] = { 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000 };
     const DiyFp one(uint64_t(1) << -Mp.e, Mp.e);
     const DiyFp wp_w = Mp - W;
@@ -124,6 +131,7 @@ inline void Grisu2(double value, char* buffer, int* length, int* K) {
 }
 
 inline char* WriteExponent(int K, char* buffer) {
+    RAPIDJSON_ASSERT(buffer != nullptr);
     if (K < 0) {
         *buffer++ = '-';
         K = -K;
@@ -133,11 +141,13 @@ inline char* WriteExponent(int K, char* buffer) {
         *buffer++ = static_cast<char>('0' + static_cast<char>(K / 100));
         K %= 100;
         const char* d = GetDigitsLut() + K * 2;
+        RAPIDJSON_ASSERT(d != nullptr);
         *buffer++ = d[0];
         *buffer++ = d[1];
     }
     else if (K >= 10) {
         const char* d = GetDigitsLut() + K * 2;
+        RAPIDJSON_ASSERT(d != nullptr);
         *buffer++ = d[0];
         *buffer++ = d[1];
     }
@@ -148,6 +158,7 @@ inline char* WriteExponent(int K, char* buffer) {
 }
 
 inline char* Prettify(char* buffer, int length, int k, int maxDecimalPlaces) {
+    RAPIDJSON_ASSERT(buffer != nullptr);
     const int kk = length + k;  // 10^(kk-1) <= v < 10^kk
 
     if (0 <= k && kk <= 21) {
@@ -214,6 +225,7 @@ inline char* Prettify(char* buffer, int length, int k, int maxDecimalPlaces) {
 }
 
 inline char* dtoa(double value, char* buffer, int maxDecimalPlaces = 324) {
+    RAPIDJSON_ASSERT(buffer != nullptr);
     RAPIDJSON_ASSERT(maxDecimalPlaces >= 1);
     Double d(value);
     if (d.IsZero()) {

--- a/include/rapidjson/internal/dtoa.h
+++ b/include/rapidjson/internal/dtoa.h
@@ -99,7 +99,7 @@ inline void DigitGen(const DiyFp& W, const DiyFp& Mp, uint64_t delta, char* buff
         delta *= 10;
         char d = static_cast<char>(p2 >> -one.e);
         if (d || len)
-            buffer[(len)++] = static_cast<char>('0' + d);
+            buffer[len++] = static_cast<char>('0' + d);
         p2 &= one.f - 1;
         kappa--;
         if (p2 < delta) {

--- a/include/rapidjson/internal/itoa.h
+++ b/include/rapidjson/internal/itoa.h
@@ -41,6 +41,7 @@ inline char* u32toa(uint32_t value, char* buffer) {
 
     const char* cDigitsLut = GetDigitsLut();
     RAPIDJSON_ASSERT(cDigitsLut != nullptr);
+
     if (value < 10000) {
         const uint32_t d1 = (value / 100) << 1;
         const uint32_t d2 = (value % 100) << 1;

--- a/include/rapidjson/internal/itoa.h
+++ b/include/rapidjson/internal/itoa.h
@@ -40,7 +40,7 @@ inline char* u32toa(uint32_t value, char* buffer) {
     RAPIDJSON_ASSERT(buffer != 0);
 
     const char* cDigitsLut = GetDigitsLut();
-
+    RAPIDJSON_ASSERT(cDigitsLut != nullptr);
     if (value < 10000) {
         const uint32_t d1 = (value / 100) << 1;
         const uint32_t d2 = (value % 100) << 1;
@@ -126,6 +126,7 @@ inline char* i32toa(int32_t value, char* buffer) {
 inline char* u64toa(uint64_t value, char* buffer) {
     RAPIDJSON_ASSERT(buffer != 0);
     const char* cDigitsLut = GetDigitsLut();
+    RAPIDJSON_ASSERT(cDigitsLut != nullptr);
     const uint64_t  kTen8 = 100000000;
     const uint64_t  kTen9 = kTen8 * 10;
     const uint64_t kTen10 = kTen8 * 100;

--- a/include/rapidjson/internal/strtod.h
+++ b/include/rapidjson/internal/strtod.h
@@ -111,6 +111,7 @@ inline int CheckWithinHalfULP(double b, const BigInteger& d, int dExp) {
 }
 
 inline bool StrtodFast(double d, int p, double* result) {
+    RAPIDJSON_ASSERT(result != nullptr);
     // Use fast path for string-to-double conversion if possible
     // see http://www.exploringbinary.com/fast-path-decimal-to-floating-point-conversion/
     if (p > 22  && p < 22 + 16) {
@@ -129,6 +130,11 @@ inline bool StrtodFast(double d, int p, double* result) {
 
 // Compute an approximation and see if it is within 1/2 ULP
 inline bool StrtodDiyFp(const char* decimals, int dLen, int dExp, double* result) {
+<<<<<<< Updated upstream
+=======
+    RAPIDJSON_ASSERT(decimals != nullptr);
+    RAPIDJSON_ASSERT(result != nullptr);
+>>>>>>> Stashed changes
     uint64_t significand = 0;
     int i = 0;   // 2^64 - 1 = 18446744073709551615, 1844674407370955161 = 0x1999999999999999    
     for (; i < dLen; i++) {
@@ -224,6 +230,10 @@ inline double StrtodBigInteger(double approx, const char* decimals, int dLen, in
 }
 
 inline double StrtodFullPrecision(double d, int p, const char* decimals, size_t length, size_t decimalPosition, int exp) {
+<<<<<<< Updated upstream
+=======
+    RAPIDJSON_ASSERT(decimals != nullptr);
+>>>>>>> Stashed changes
     RAPIDJSON_ASSERT(d >= 0.0);
     RAPIDJSON_ASSERT(length >= 1);
 

--- a/include/rapidjson/internal/strtod.h
+++ b/include/rapidjson/internal/strtod.h
@@ -113,7 +113,6 @@ inline int CheckWithinHalfULP(double b, const BigInteger& d, int dExp) {
 inline bool StrtodFast(double d, int p, double* result) {
     // Use fast path for string-to-double conversion if possible
     // see http://www.exploringbinary.com/fast-path-decimal-to-floating-point-conversion/
-    RAPIDJSON_ASSERT(result != nullptr);
     if (p > 22  && p < 22 + 16) {
         // Fast Path Cases In Disguise
         d *= internal::Pow10(p - 22);
@@ -121,6 +120,7 @@ inline bool StrtodFast(double d, int p, double* result) {
     }
 
     if (p >= -22 && p <= 22 && d <= 9007199254740991.0) { // 2^53 - 1
+        RAPIDJSON_ASSERT(result != nullptr);
         *result = FastPath(d, p);
         return true;
     }

--- a/include/rapidjson/internal/strtod.h
+++ b/include/rapidjson/internal/strtod.h
@@ -130,11 +130,8 @@ inline bool StrtodFast(double d, int p, double* result) {
 
 // Compute an approximation and see if it is within 1/2 ULP
 inline bool StrtodDiyFp(const char* decimals, int dLen, int dExp, double* result) {
-<<<<<<< Updated upstream
-=======
     RAPIDJSON_ASSERT(decimals != nullptr);
     RAPIDJSON_ASSERT(result != nullptr);
->>>>>>> Stashed changes
     uint64_t significand = 0;
     int i = 0;   // 2^64 - 1 = 18446744073709551615, 1844674407370955161 = 0x1999999999999999    
     for (; i < dLen; i++) {
@@ -230,10 +227,7 @@ inline double StrtodBigInteger(double approx, const char* decimals, int dLen, in
 }
 
 inline double StrtodFullPrecision(double d, int p, const char* decimals, size_t length, size_t decimalPosition, int exp) {
-<<<<<<< Updated upstream
-=======
     RAPIDJSON_ASSERT(decimals != nullptr);
->>>>>>> Stashed changes
     RAPIDJSON_ASSERT(d >= 0.0);
     RAPIDJSON_ASSERT(length >= 1);
 

--- a/include/rapidjson/internal/strtod.h
+++ b/include/rapidjson/internal/strtod.h
@@ -111,9 +111,9 @@ inline int CheckWithinHalfULP(double b, const BigInteger& d, int dExp) {
 }
 
 inline bool StrtodFast(double d, int p, double* result) {
-    RAPIDJSON_ASSERT(result != nullptr);
     // Use fast path for string-to-double conversion if possible
     // see http://www.exploringbinary.com/fast-path-decimal-to-floating-point-conversion/
+    RAPIDJSON_ASSERT(result != nullptr);
     if (p > 22  && p < 22 + 16) {
         // Fast Path Cases In Disguise
         d *= internal::Pow10(p - 22);

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -273,6 +273,7 @@ void SkipWhitespace(InputStream& is) {
 
 inline const char* SkipWhitespace(const char* p, const char* end) {
     while (p != end && (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t'))
+        RAPIDJSON_ASSERT(p != nullptr);
         ++p;
     return p;
 }

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -272,7 +272,8 @@ void SkipWhitespace(InputStream& is) {
 }
 
 inline const char* SkipWhitespace(const char* p, const char* end) {
-    while (p != nullptr && p != end && (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t'))
+    RAPIDJSON_ASSERT(p);
+    while (p != end && (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t'))
         ++p;
     return p;
 }

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1576,7 +1576,7 @@ private:
 
         // Parse frac = decimal-point 1*DIGIT
         int expFrac = 0;
-        size_t decimalPosition = 0;
+        size_t decimalPosition;
         if (Consume(s, '.')) {
             decimalPosition = s.Length();
 

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1576,7 +1576,7 @@ private:
 
         // Parse frac = decimal-point 1*DIGIT
         int expFrac = 0;
-        size_t decimalPosition;
+        size_t decimalPosition = 0;
         if (Consume(s, '.')) {
             decimalPosition = s.Length();
 

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -272,8 +272,7 @@ void SkipWhitespace(InputStream& is) {
 }
 
 inline const char* SkipWhitespace(const char* p, const char* end) {
-    while (p != end && (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t'))
-        RAPIDJSON_ASSERT(p != nullptr);
+    while (p != nullptr && p != end && (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t'))
         ++p;
     return p;
 }


### PR DESCRIPTION
### [ADO](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**ado**)
- https://dev-mc.visualstudio.com/Minecraft/_workitems/edit/647089

<!-- *** EDIT_NUMBER_INTO_LINK_ABOVE_REPLACING_### ***
    - Include a link to each work item on ADO for the user story, bugfix, etc.
    - If there is not an ADO work item for the PR, then consider making one.
-->



### [Description / PR Commit Message](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**description-%2F-pr-commit-message**)

<!-- *** COMMENT_DESCRIPTION_PR_COMMIT_MESSAGE ***
    - Add a description of the PR and why it is being made.
    - May contain root cause, perf impact, background info, system design, changes made, creator impact, etc.
    - Upon merging, copy the text you typed below here and use that as the PR Commit Message.
-->
Fixed 19 errors from Error Type C26429:
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\itoa.h(42)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\itoa.h(128)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\dtoa.h(35)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\dtoa.h(60)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\dtoa.h(140)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\dtoa.h(135)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\dtoa.h(126)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\dtoa.h(150)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\dtoa.h(216)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\biginteger.h(241)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\biginteger.h(249)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\diyfp.h(238)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\diyfp.h(252)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\strtod.h(113)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\strtod.h(131)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\strtod.h(226)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\reader.h(274)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\strtod.h(131)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\document.h(806)
  C:\Minecraftpe\handheld\src-external\rapidjson_\rapidjson\include\rapidjson\document.h(2068)


</body>

</html>




### [Guidance for Review](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**guidance-for-review**)
I used reference whenever possible and RAPIDJASON_ASSERT when reference not applicable.
<!-- *** COMMENT__GUIDANCE_FOR_REVIEW ***
    - Provide additional information to ease review of this PR; this section does not survive into git history.
    - May contain: what you dev tested, perf captures, screenshots, requested feedback, recommended order to review files in, auto test reliability results, changelog exemption reason, test review exemption reason, etc.
-->



### [Author's Checklist](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**author%27s-checklist**)
- [ ] Completed Automated Test Review or have Exemption ([automated test policy](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/4447)).
- [ ] Have Changelogs for Public Changes or have Exemption ([changelogs policy](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/3921/Pull-Request-Changelogs)).
- [x] Set the Manual Quality Validation Required field and applicable Validation Notes in ADO item(s).
- [x] Builds and Test Runs passed.
- [x] Reliability runs of affected tests passed (Unit 1 time, Server 10 time, Functional 50 times).



### [Reviewers' Checklist](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**reviewers%27-checklist**)
- [ ] Correct target branch.
- [ ] Reason/root cause understood; documented in Description / PR Commit message.
- [ ] Architecturally fits accepted patterns.
- [ ] Introduced no known bugs and is secure.
- [ ] No hard-coded "secrets".
- [ ] Follows Coding Standards ([contributing.md](https://github.com/Mojang/Minecraftpe/blob/main/CONTRIBUTING.md)).
- [ ] Content creator impact is understood and acceptable.
