### PR TITLE
User Story AB#648507: Enable PREFast warnings as errors. [Error Type: C26451: Arithmetic overflow] -Minecraft.Shared.Splits-Submodule rapidjson&Scripting_

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -2073,7 +2073,7 @@ private:
         } else {
             data_.f.flags = kCopyStringFlag;
             data_.s.length = s.length;
-            str = static_cast<Ch *>(allocator.Malloc((s.length + 1) * sizeof(Ch)));
+            str = static_cast<Ch *>(allocator.Malloc(( static_cast<uint64_t>(s.length) + 1) * sizeof(Ch)));
             SetStringPointer(str);
         }
         std::memcpy(str, s, s.length * sizeof(Ch));

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -2074,7 +2074,7 @@ private:
             data_.f.flags = kCopyStringFlag;
             data_.s.length = s.length;
             uint64_t mallocLength = static_cast<uint64_t>(s.length) + 1;
-            str = static_cast<Ch *>(allocator.Malloc(static_cast<int32_t>(mallocLength)* sizeof(Ch)));
+            str = static_cast<Ch *>(allocator.Malloc(static_cast<int32_t>(mallocLength) * sizeof(Ch)));
             SetStringPointer(str);
         }
         std::memcpy(str, s, s.length * sizeof(Ch));

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -2073,7 +2073,8 @@ private:
         } else {
             data_.f.flags = kCopyStringFlag;
             data_.s.length = s.length;
-            str = static_cast<Ch *>(allocator.Malloc(( static_cast<uint64_t>(s.length) + 1) * sizeof(Ch)));
+            uint64_t mallocLength = static_cast<uint64_t>(s.length) + 1;
+            str = static_cast<Ch *>(allocator.Malloc(static_cast<int32_t>(mallocLength)* sizeof(Ch)));
             SetStringPointer(str);
         }
         std::memcpy(str, s, s.length * sizeof(Ch));

--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -241,7 +241,7 @@ private:
         uint64_t r = 0;
         for (const char* p = begin; p != end; ++p) {
             RAPIDJSON_ASSERT(*p >= '0' && *p <= '9');
-            r = r * 10u + static_cast<unsigned>(*p - '0');
+            r = r * 10u + static_cast<unsigned>(*p - static_cast<uint64_t>('0'));
         }
         return r;
     }

--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -241,7 +241,7 @@ private:
         uint64_t r = 0;
         for (const char* p = begin; p != end; ++p) {
             RAPIDJSON_ASSERT(*p >= '0' && *p <= '9');
-            r = r * 10u + *p - '0';
+            r = r * 10u + static_cast<unsigned>(*p) - '0';
         }
         return r;
     }

--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -241,7 +241,7 @@ private:
         uint64_t r = 0;
         for (const char* p = begin; p != end; ++p) {
             RAPIDJSON_ASSERT(*p >= '0' && *p <= '9');
-            r = r * 10u + static_cast<unsigned>(*p - static_cast<uint64_t>('0'));
+            r = r * 10u + *p - '0';
         }
         return r;
     }

--- a/include/rapidjson/internal/diyfp.h
+++ b/include/rapidjson/internal/diyfp.h
@@ -132,7 +132,7 @@ struct DiyFp {
     void NormalizedBoundaries(DiyFp* minus, DiyFp* plus) const {
         DiyFp pl = DiyFp((f << 1) + 1, e - 1).NormalizeBoundary();
         DiyFp mi = (f == kDpHiddenBit) ? DiyFp((f << 2) - 1, e - 2) : DiyFp((f << 1) - 1, e - 1);
-        mi.f  = mi.f << (mi.e - pl.e);
+        mi.f <<= static_cast<uint64_t>(mi.e) - pl.e;
         mi.e = pl.e;
         *plus = pl;
         *minus = mi;

--- a/include/rapidjson/internal/diyfp.h
+++ b/include/rapidjson/internal/diyfp.h
@@ -132,7 +132,7 @@ struct DiyFp {
     void NormalizedBoundaries(DiyFp* minus, DiyFp* plus) const {
         DiyFp pl = DiyFp((f << 1) + 1, e - 1).NormalizeBoundary();
         DiyFp mi = (f == kDpHiddenBit) ? DiyFp((f << 2) - 1, e - 2) : DiyFp((f << 1) - 1, e - 1);
-        mi.f <<= mi.e - pl.e;
+        mi.f  = mi.f << (mi.e - pl.e);
         mi.e = pl.e;
         *plus = pl;
         *minus = mi;
@@ -153,7 +153,7 @@ struct DiyFp {
             return std::numeric_limits<double>::infinity();
         }
         const uint64_t be = (e == kDpDenormalExponent && (f & kDpHiddenBit) == 0) ? 0 :
-            static_cast<uint64_t>(e + kDpExponentBias);
+            static_cast<uint64_t>(e) + kDpExponentBias;
         u.u64 = (f & kDpSignificandMask) | (be << kDpSignificandSize);
         return u.d;
     }
@@ -238,7 +238,7 @@ inline DiyFp GetCachedPowerByIndex(size_t index) {
 inline DiyFp GetCachedPower(int e, int* K) {
 
     //int k = static_cast<int>(ceil((-61 - e) * 0.30102999566398114)) + 374;
-    double dk = (-61 - e) * 0.30102999566398114 + 347;  // dk must be positive, so can do ceiling in positive
+    double dk = (static_cast<double>(-61) - e) * 0.30102999566398114 + 347;  // dk must be positive, so can do ceiling in positive
     int k = static_cast<int>(dk);
     if (dk - k > 0.0)
         k++;

--- a/include/rapidjson/internal/dtoa.h
+++ b/include/rapidjson/internal/dtoa.h
@@ -132,12 +132,12 @@ inline char* WriteExponent(int K, char* buffer) {
     if (K >= 100) {
         *buffer++ = static_cast<char>('0' + static_cast<char>(K / 100));
         K %= 100;
-        const char* d = GetDigitsLut() + K * 2;
+        const char* d = GetDigitsLut() + static_cast<int64_t>(K) * 2;
         *buffer++ = d[0];
         *buffer++ = d[1];
     }
     else if (K >= 10) {
-        const char* d = GetDigitsLut() + K * 2;
+        const char* d = GetDigitsLut() + static_cast<int64_t>(K) * 2;
         *buffer++ = d[0];
         *buffer++ = d[1];
     }
@@ -160,7 +160,7 @@ inline char* Prettify(char* buffer, int length, int k, int maxDecimalPlaces) {
     }
     else if (0 < kk && kk <= 21) {
         // 1234e-2 -> 12.34
-        std::memmove(&buffer[kk + 1], &buffer[kk], static_cast<size_t>(length - kk));
+        std::memmove(&buffer[kk + 1], &buffer[kk], static_cast<size_t>(length) - kk);
         buffer[kk] = '.';
         if (0 > k + maxDecimalPlaces) {
             // When maxDecimalPlaces = 2, 1.2345 -> 1.23, 1.102 -> 1.1
@@ -206,7 +206,7 @@ inline char* Prettify(char* buffer, int length, int k, int maxDecimalPlaces) {
     }
     else {
         // 1234e30 -> 1.234e33
-        std::memmove(&buffer[2], &buffer[1], static_cast<size_t>(length - 1));
+        std::memmove(&buffer[2], &buffer[1], static_cast<size_t>(length) - 1);
         buffer[1] = '.';
         buffer[length + 1] = 'e';
         return WriteExponent(kk - 1, &buffer[0 + length + 2]);

--- a/include/rapidjson/internal/strtod.h
+++ b/include/rapidjson/internal/strtod.h
@@ -135,7 +135,7 @@ inline bool StrtodDiyFp(const char* decimals, int dLen, int dExp, double* result
         if (significand  >  RAPIDJSON_UINT64_C2(0x19999999, 0x99999999) ||
             (significand == RAPIDJSON_UINT64_C2(0x19999999, 0x99999999) && decimals[i] > '5'))
             break;
-        significand = significand * 10u + static_cast<unsigned>(decimals[i] - '0');
+        significand = significand * 10u + static_cast<unsigned>(static_cast<uint64_t>(decimals[i]) - '0');
     }
     
     if (i < dLen && decimals[i] >= '5') // Rounding
@@ -173,11 +173,11 @@ inline bool StrtodDiyFp(const char* decimals, int dLen, int dExp, double* result
 
     v = v * cachedPower;
 
-    error += kUlp + (error == 0 ? 0 : 1);
+    error += static_cast<int64_t>(kUlp) + (error == 0 ? 0 : 1);
 
     const int oldExp = v.e;
     v = v.Normalize();
-    error <<= oldExp - v.e;
+    error = error << (oldExp - v.e);
 
     const int effectiveSignificandSize = Double::EffectiveSignificandSize(64 + v.e);
     int precisionSize = 64 - effectiveSignificandSize;

--- a/include/rapidjson/internal/strtod.h
+++ b/include/rapidjson/internal/strtod.h
@@ -135,7 +135,7 @@ inline bool StrtodDiyFp(const char* decimals, int dLen, int dExp, double* result
         if (significand  >  RAPIDJSON_UINT64_C2(0x19999999, 0x99999999) ||
             (significand == RAPIDJSON_UINT64_C2(0x19999999, 0x99999999) && decimals[i] > '5'))
             break;
-        significand = significand * 10u + static_cast<unsigned>(static_cast<uint64_t>(decimals[i]) - '0');
+        significand = significand * 10u + static_cast<unsigned>(decimals[i]) - '0';
     }
     
     if (i < dLen && decimals[i] >= '5') // Rounding
@@ -173,7 +173,7 @@ inline bool StrtodDiyFp(const char* decimals, int dLen, int dExp, double* result
 
     v = v * cachedPower;
 
-    error += static_cast<int64_t>(kUlp) + (error == 0 ? 0 : 1);
+    error = error + kUlp + (error == 0 ? 0 : 1);
 
     const int oldExp = v.e;
     v = v.Normalize();

--- a/include/rapidjson/internal/strtod.h
+++ b/include/rapidjson/internal/strtod.h
@@ -135,7 +135,7 @@ inline bool StrtodDiyFp(const char* decimals, int dLen, int dExp, double* result
         if (significand  >  RAPIDJSON_UINT64_C2(0x19999999, 0x99999999) ||
             (significand == RAPIDJSON_UINT64_C2(0x19999999, 0x99999999) && decimals[i] > '5'))
             break;
-        significand = significand * 10u + decimals[i] - '0';
+        significand = significand * 10u + static_cast<unsigned>(decimals[i]) - '0';
     }
     
     if (i < dLen && decimals[i] >= '5') // Rounding

--- a/include/rapidjson/internal/strtod.h
+++ b/include/rapidjson/internal/strtod.h
@@ -173,11 +173,11 @@ inline bool StrtodDiyFp(const char* decimals, int dLen, int dExp, double* result
 
     v = v * cachedPower;
 
-    error = error + kUlp + (error == 0 ? 0 : 1);
+    error += static_cast<int64_t>(kUlp) + (error == 0 ? 0 : 1);
 
     const int oldExp = v.e;
     v = v.Normalize();
-    error = error << (oldExp - v.e);
+    error <<= static_cast<int64_t>(oldExp) - v.e;
 
     const int effectiveSignificandSize = Double::EffectiveSignificandSize(64 + v.e);
     int precisionSize = 64 - effectiveSignificandSize;

--- a/include/rapidjson/internal/strtod.h
+++ b/include/rapidjson/internal/strtod.h
@@ -135,7 +135,7 @@ inline bool StrtodDiyFp(const char* decimals, int dLen, int dExp, double* result
         if (significand  >  RAPIDJSON_UINT64_C2(0x19999999, 0x99999999) ||
             (significand == RAPIDJSON_UINT64_C2(0x19999999, 0x99999999) && decimals[i] > '5'))
             break;
-        significand = significand * 10u + static_cast<unsigned>(decimals[i]) - '0';
+        significand = significand * 10u + decimals[i] - '0';
     }
     
     if (i < dLen && decimals[i] >= '5') // Rounding

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1496,7 +1496,7 @@ private:
                             break;
                         }
                     }
-                    i = i * 10 + static_cast<unsigned>(s.TakePush() - '0');
+                    i = i * 10 + static_cast<unsigned>(static_cast<unsigned int>(s.TakePush()) - '0');
                     significandDigit++;
                 }
             else
@@ -1550,7 +1550,7 @@ private:
                             useDouble = true;
                             break;
                         }
-                    i64 = i64 * 10 + static_cast<unsigned>(s.TakePush() - '0');
+                    i64 = i64 * 10 + static_cast<unsigned>(static_cast<uint64_t>(s.TakePush()) - '0');
                     significandDigit++;
                 }
             else
@@ -1561,7 +1561,7 @@ private:
                             useDouble = true;
                             break;
                         }
-                    i64 = i64 * 10 + static_cast<unsigned>(s.TakePush() - '0');
+                    i64 = i64 * 10 + static_cast<unsigned>(static_cast<uint64_t>(s.TakePush()) - '0');
                     significandDigit++;
                 }
         }
@@ -1569,7 +1569,7 @@ private:
         // Force double for big integer
         if (useDouble) {
             while (RAPIDJSON_LIKELY(s.Peek() >= '0' && s.Peek() <= '9')) {
-                d = d * 10 + (s.TakePush() - '0');
+                d = d * 10 + (static_cast<uint64_t>(s.TakePush()) - '0');
             }
         }
 
@@ -1592,7 +1592,7 @@ private:
                     if (i64 > RAPIDJSON_UINT64_C2(0x1FFFFF, 0xFFFFFFFF)) // 2^53 - 1 for fast path
                         break;
                     else {
-                        i64 = i64 * 10 + static_cast<unsigned>(s.TakePush() - '0');
+                        i64 = i64 * 10 + static_cast<unsigned>(static_cast<uint64_t>(s.TakePush()) - '0');
                         --expFrac;
                         if (i64 != 0)
                             significandDigit++;
@@ -1609,7 +1609,7 @@ private:
 
             while (RAPIDJSON_LIKELY(s.Peek() >= '0' && s.Peek() <= '9')) {
                 if (significandDigit < 17) {
-                    d = d * 10.0 + (s.TakePush() - '0');
+                    d = d * 10.0 + (static_cast<uint64_t>(s.TakePush()) - '0');
                     --expFrac;
                     if (RAPIDJSON_LIKELY(d > 0.0))
                         significandDigit++;

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1496,7 +1496,7 @@ private:
                             break;
                         }
                     }
-                    i = i * 10 + static_cast<unsigned>(static_cast<unsigned int>(s.TakePush()) - '0');
+                    i = i * 10 + static_cast<unsigned>(s.TakePush()) - '0';
                     significandDigit++;
                 }
             else
@@ -1550,7 +1550,7 @@ private:
                             useDouble = true;
                             break;
                         }
-                    i64 = i64 * 10 + static_cast<unsigned>(static_cast<uint64_t>(s.TakePush()) - '0');
+                    i64 = i64 * 10 + static_cast<unsigned>(s.TakePush()) - '0';
                     significandDigit++;
                 }
             else
@@ -1561,7 +1561,7 @@ private:
                             useDouble = true;
                             break;
                         }
-                    i64 = i64 * 10 + static_cast<unsigned>(static_cast<uint64_t>(s.TakePush()) - '0');
+                    i64 = i64 * 10 + s.TakePush() - '0';
                     significandDigit++;
                 }
         }
@@ -1569,7 +1569,7 @@ private:
         // Force double for big integer
         if (useDouble) {
             while (RAPIDJSON_LIKELY(s.Peek() >= '0' && s.Peek() <= '9')) {
-                d = d * 10 + (static_cast<uint64_t>(s.TakePush()) - '0');
+                d = d * 10 + static_cast<unsigned>(s.TakePush()) - '0';
             }
         }
 
@@ -1592,7 +1592,7 @@ private:
                     if (i64 > RAPIDJSON_UINT64_C2(0x1FFFFF, 0xFFFFFFFF)) // 2^53 - 1 for fast path
                         break;
                     else {
-                        i64 = i64 * 10 + static_cast<unsigned>(static_cast<uint64_t>(s.TakePush()) - '0');
+                        i64 = i64 * 10 + static_cast<unsigned>(s.TakePush()) - '0';
                         --expFrac;
                         if (i64 != 0)
                             significandDigit++;
@@ -1609,7 +1609,7 @@ private:
 
             while (RAPIDJSON_LIKELY(s.Peek() >= '0' && s.Peek() <= '9')) {
                 if (significandDigit < 17) {
-                    d = d * 10.0 + (static_cast<uint64_t>(s.TakePush()) - '0');
+                    d = d * 10.0 + static_cast<unsigned>(s.TakePush()) - '0';
                     --expFrac;
                     if (RAPIDJSON_LIKELY(d > 0.0))
                         significandDigit++;

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1561,7 +1561,7 @@ private:
                             useDouble = true;
                             break;
                         }
-                    i64 = i64 * 10 + s.TakePush() - '0';
+                    i64 = i64 * 10 + static_cast<unsigned>(s.TakePush()) - '0';
                     significandDigit++;
                 }
         }

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -388,9 +388,9 @@ protected:
         };
 
         if (TargetEncoding::supportUnicode)
-            PutReserve(*os_, 2 + length * 6); // "\uxxxx..."
+            PutReserve(*os_, static_cast<size_t>(2) + static_cast<size_t>(length) * 6); // "\uxxxx..."
         else
-            PutReserve(*os_, 2 + length * 12);  // "\uxxxx\uyyyy..."
+            PutReserve(*os_, static_cast<size_t>(2) + static_cast<size_t>(length) * 12);  // "\uxxxx\uyyyy..."
 
         PutUnsafe(*os_, '\"');
         GenericStringStream<SourceEncoding> is(str);

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -388,9 +388,9 @@ protected:
         };
 
         if (TargetEncoding::supportUnicode)
-            PutReserve(*os_, static_cast<size_t>(2) + static_cast<size_t>(length) * 6); // "\uxxxx..."
+            PutReserve(*os_, 2 + static_cast<size_t>(length) * 6); // "\uxxxx..."
         else
-            PutReserve(*os_, static_cast<size_t>(2) + static_cast<size_t>(length) * 12);  // "\uxxxx\uyyyy..."
+            PutReserve(*os_, 2 + static_cast<size_t>(length) * 12);  // "\uxxxx\uyyyy..."
 
         PutUnsafe(*os_, '\"');
         GenericStringStream<SourceEncoding> is(str);


### PR DESCRIPTION
### [ADO](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**ado**)
- https://dev-mc.visualstudio.com/Minecraft/_workitems/edit/648507

<!-- *** EDIT_NUMBER_INTO_LINK_ABOVE_REPLACING_### ***
    - Include a link to each work item on ADO for the user story, bugfix, etc.
    - If there is not an ADO work item for the PR, then consider making one.
-->



### [Description / PR Commit Message](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**description-%2F-pr-commit-message**)

<!-- *** COMMENT_DESCRIPTION_PR_COMMIT_MESSAGE ***
    - Add a description of the PR and why it is being made.
    - May contain root cause, perf impact, background info, system design, changes made, creator impact, etc.
    - Upon merging, copy the text you typed below here and use that as the PR Commit Message.
-->

Check with PREFast, found 19 error:

```
1. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\biginteger.h(244) warning C26451 Arithmetic overflow Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).
2. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\diyfp.h(135) warning C26451 Arithmetic overflow Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).
3. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\diyfp.h(156) warning C26451 Arithmetic overflow Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2).
4. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\diyfp.h(241) warning C26451 Arithmetic overflow Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).
5. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\strtod.h(138) warning C26451 Arithmetic overflow Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).
6. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\strtod.h(176) warning C26451 Arithmetic overflow Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2).
7. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\strtod.h(180) warning C26451 Arithmetic overflow Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).
8. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\reader.h(1553) warning C26451 Arithmetic overflow Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).
9. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\reader.h(1564) warning C26451 Arithmetic overflow Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).
10. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\reader.h(1572) warning C26451 Arithmetic overflow Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).
11. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\reader.h(1595) warning C26451 Arithmetic overflow Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).
12. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\reader.h(1612) warning C26451 Arithmetic overflow Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).
13. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\document.h(2076) warning C26451 Arithmetic overflow Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2).
14. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\dtoa.h(135) warning C26451 Arithmetic overflow Using operator '*' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '*' to avoid overflow (io.2).
15. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\dtoa.h(140) warning C26451 Arithmetic overflow Using operator '*' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '*' to avoid overflow (io.2).
16. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\dtoa.h(163) warning C26451 Arithmetic overflow Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).
17. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\internal\dtoa.h(209) warning C26451 Arithmetic overflow Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).
18. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\writer.h(391) warning C26451 Arithmetic overflow Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2).
19. \handheld\src-external\rapidjson_\rapidjson\include\rapidjson\writer.h(393) warning C26451 Arithmetic overflow Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2).

```
The modifications are as following:
Perform a type conversion to avoid errors


### [Guidance for Review](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**guidance-for-review**)

<!-- *** COMMENT__GUIDANCE_FOR_REVIEW ***
    - Provide additional information to ease review of this PR; this section does not survive into git history.
    - May contain: what you dev tested, perf captures, screenshots, requested feedback, recommended order to review files in, auto test reliability results, changelog exemption reason, test review exemption reason, etc.
-->
Synchronize with main on 2021-11-05.


### [Author's Checklist](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**author%27s-checklist**)
- [ ] Completed Automated Test Review or have Exemption ([automated test policy](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/4447)).
- [ ] Have Changelogs for Public Changes or have Exemption ([changelogs policy](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/3921/Pull-Request-Changelogs)).
- [x] Set the Manual Quality Validation Required field and applicable Validation Notes in ADO item(s).
- [x] Builds and Test Runs passed.
- [x] Reliability runs of affected tests passed (Unit 1 time, Server 10 time, Functional 50 times).



### [Reviewers' Checklist](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**reviewers%27-checklist**)
- [ ] Correct target branch.
- [ ] Reason/root cause understood; documented in Description / PR Commit message.
- [ ] Architecturally fits accepted patterns.
- [ ] Introduced no known bugs and is secure.
- [ ] No hard-coded "secrets".
- [ ] Follows Coding Standards ([contributing.md](https://github.com/Mojang/Minecraftpe/blob/main/CONTRIBUTING.md)).
- [ ] Content creator impact is understood and acceptable.
